### PR TITLE
Added hostname configuration on wan and lan

### DIFF
--- a/usr/lib/lua/luci/controller/arduino/index.lua
+++ b/usr/lib/lua/luci/controller/arduino/index.lua
@@ -465,6 +465,8 @@ function config_post()
   if not_nil_or_empty(params["hostname"]) then
     local hostname = string.gsub(params["hostname"], " ", "_")
     set_first(uci, "system", "system", "hostname", hostname)
+    uci:set("network", "lan", "hostname", hostname)
+    uci:set("network", "wan", "hostname", hostname)
   end
 
   if params["zonename"] then


### PR DESCRIPTION
Changing the name of the board via the webpanel now adds the hostname to the network configuration.
Fixes https://github.com/arduino/YunWebUI/issues/19